### PR TITLE
Refactor API status codes and standardize response format with `MessageDto`

### DIFF
--- a/Rent.Motorcycle.API/Dtos.cs
+++ b/Rent.Motorcycle.API/Dtos.cs
@@ -80,3 +80,8 @@ public record PreviewVm(
 
 public record ReturnDto(
     [property: JsonPropertyName("data_retorno")] DateTimeOffset returnDate);
+
+
+
+public sealed record MessageDto(string mensagem);
+

--- a/Rent.Motorcycle.API/Program.cs
+++ b/Rent.Motorcycle.API/Program.cs
@@ -65,11 +65,11 @@ app.UseSwaggerUI(c =>
 var motorcyle = app.MapGroup("/motos").WithTags("motos");
 
 // POST /motos
-motorcyle.MapPost("", async Task<Results<Created<MotoVm>, BadRequest<object>, Conflict>> (
+motorcyle.MapPost("", async Task<IResult> (
     MotoCreateDto dto, RentDbContext db, IEventBus bus, CancellationToken ct) =>
 {
     if (string.IsNullOrWhiteSpace(dto.id) || string.IsNullOrWhiteSpace(dto.model) || string.IsNullOrWhiteSpace(dto.plate))
-        return TypedResults.BadRequest(BadRequestMsg());
+        return Results.BadRequest(new MessageDto("Dados inválidos"));
 
     var normalizedPlate = Motorcycle.NormalizePlate(dto.plate);
 
@@ -88,13 +88,39 @@ motorcyle.MapPost("", async Task<Results<Created<MotoVm>, BadRequest<object>, Co
         return TypedResults.Created($"/motos/{moto.Id}",
             new MotoVm(moto.Id, moto.Year, moto.Model, moto.Plate));
     }
-    catch (ArgumentException ex) { return TypedResults.BadRequest(BadRequestMsg(ex.Message)); }
+    catch (ArgumentException)
+    {
+        return Results.BadRequest(new MessageDto( "Dados inválidos"));
+    }
+
 })
 .WithSummary("Cadastrar uma nova moto")
-.WithDescription("Cria um registro de motocicleta.")
-.Produces<MotoVm>(StatusCodes.Status201Created)
-.Produces(StatusCodes.Status409Conflict)
-.Produces<object>(StatusCodes.Status400BadRequest);
+.WithOpenApi(op =>
+{
+    op.Responses["201"] = new OpenApiResponse
+    {
+        Description = "Moto cadastrada",
+    };
+
+    op.Responses["400"] = new OpenApiResponse
+    {
+        Description = "Dados inválidos",
+        Content =
+        {
+            ["application/json"] = new OpenApiMediaType
+            {
+                Example = new OpenApiObject
+                {
+                    ["mensagem"] = new OpenApiString("Dados inválidos")
+                }
+            }
+        }
+    };
+    return op;
+})
+.Produces<RiderVm>(StatusCodes.Status201Created, "application/json")
+.Produces<MessageDto>(StatusCodes.Status400BadRequest, "application/json");
+
 
 // GET /motos
 motorcyle.MapGet("", async (string? plate, RentDbContext db, CancellationToken ct) =>
@@ -107,81 +133,238 @@ motorcyle.MapGet("", async (string? plate, RentDbContext db, CancellationToken c
     return Results.Ok(list);
 })
 .WithSummary("Consultar motos existentes")
-.WithDescription("Retorna a lista de motos, com filtro opcional por placa.")
+.WithOpenApi(op =>
+{
+    op.Responses["200"] = new OpenApiResponse
+    {
+        Description = "Lista de motos",
+        Content =
+        {
+            ["application/json"] = new OpenApiMediaType
+            {
+                Example = new OpenApiObject
+                {
+                    ["id"]    = new OpenApiString("moto123"),
+                    ["year"]  = new OpenApiInteger(2020),
+                    ["model"] = new OpenApiString("Mottu Sport"),
+                    ["plate"] = new OpenApiString("CDX-0101")
+                }
+            }
+        }
+    };
+
+    return op;
+})
 .Produces<IEnumerable<MotoVm>>(StatusCodes.Status200OK);
 
 
 // PUT /motos/{id}/placa
-motorcyle.MapPut("/{id}/placa", async Task<Results<NoContent, NotFound, Conflict, BadRequest<object>>> (
-    string id, ChangePlateDto dto, RentDbContext db, CancellationToken ct) =>
+motorcyle.MapPut("/{id}/placa", async Task<IResult> (
+    string id,
+    ChangePlateDto dto,
+    RentDbContext db,
+    CancellationToken ct) =>
 {
     if (string.IsNullOrWhiteSpace(dto.plate))
-        return TypedResults.BadRequest(BadRequestMsg("Campo 'placa' é obrigatório."));
+        return Results.BadRequest(new MessageDto("Dados inválidos"));
 
     var m = await db.Motorcycles.FindAsync(new object[] { id }, ct);
-    if (m is null) return TypedResults.NotFound();
+    if (m is null)
+        return Results.NotFound(new MessageDto("Moto não encontrada"));
 
     var normalized = Motorcycle.NormalizePlate(dto.plate);
     var plateInUse = await db.Motorcycles.AnyAsync(x => x.Plate == normalized && x.Id != id, ct);
-    if (plateInUse) return TypedResults.Conflict();
+    if (plateInUse)
+        return Results.Conflict();
 
     try
     {
         m.ChangePlate(dto.plate);
         await db.SaveChangesAsync(ct);
-        return TypedResults.NoContent();
+
+        return Results.Ok(new MessageDto("Placa modificada com sucesso"));
     }
-    catch (ArgumentException ex)
+    catch (ArgumentException)
     {
-        return TypedResults.BadRequest(BadRequestMsg(ex.Message));
+        return Results.BadRequest(new MessageDto("Dados inválidos"));
     }
 })
 .WithSummary("Modificar a placa de uma moto")
-.WithDescription("Atualiza a placa da moto informada.")
-.Produces(StatusCodes.Status204NoContent)
-.Produces(StatusCodes.Status404NotFound)
-.Produces(StatusCodes.Status409Conflict)
-.Produces<object>(StatusCodes.Status400BadRequest);
+.WithOpenApi(op =>
+{
+    op.Responses["200"] = new OpenApiResponse
+    {
+        Description = "Placa modificada com sucesso",
+        Content =
+        {
+            ["application/json"] = new OpenApiMediaType
+            {
+                Example = new OpenApiObject
+                {
+                    ["mensagem"] = new OpenApiString("Placa modificada com sucesso")
+                }
+            }
+        }
+    };
+
+    op.Responses["400"] = new OpenApiResponse
+    {
+        Description = "Dados inválidos",
+        Content =
+        {
+            ["application/json"] = new OpenApiMediaType
+            {
+                Example = new OpenApiObject
+                {
+                    ["mensagem"] = new OpenApiString("Dados inválidos")
+                }
+            }
+        }
+    };
+
+    return op;
+})
+.Produces<MessageDto>(StatusCodes.Status200OK, "application/json")
+.Produces<MessageDto>(StatusCodes.Status400BadRequest, "application/json");
 
 // GET /motos/{id}
-motorcyle.MapGet("/{id}", async (string id, RentDbContext db, CancellationToken ct) =>
+motorcyle.MapGet("/{id}", async Task<IResult> (string id, RentDbContext db, CancellationToken ct) =>
 {
-    var m = await db.Motorcycles.FindAsync(new object[] { id }, ct);
-    return m is null ? Results.NotFound() : Results.Ok(new MotoVm(m.Id, m.Year, m.Model, m.Plate));
-})
-.WithSummary("Consultar moto por id")
-.WithDescription("Retorna os dados de uma moto específica.")
-.Produces<MotoVm>(StatusCodes.Status200OK)
-.Produces(StatusCodes.Status404NotFound);
+    if (string.IsNullOrWhiteSpace(id))
+        return Results.BadRequest(new MessageDto("Request mal formada"));
 
+    var m = await db.Motorcycles.FindAsync(new object[] { id }, ct);
+    if (m is null)
+        return Results.NotFound(new MessageDto("Moto não encontrada"));
+
+    return Results.Ok(new MotoVm(m.Id, m.Year, m.Model, m.Plate));
+})
+.WithSummary("Consultar motos existentes por id")
+.WithOpenApi(op =>
+{
+    op.Responses["200"] = new OpenApiResponse
+    {
+        Description = "Detalhes da moto",
+        Content =
+        {
+            ["application/json"] = new OpenApiMediaType
+            {
+                Example = new OpenApiObject
+                {
+                    ["id"]    = new OpenApiString("moto123"),
+                    ["year"]  = new OpenApiInteger(2020),
+                    ["model"] = new OpenApiString("Mottu Sport"),
+                    ["plate"] = new OpenApiString("CDX-0101")
+                }
+            }
+        }
+    };
+
+    op.Responses["400"] = new OpenApiResponse
+    {
+        Description = "Request mal formada",
+        Content =
+        {
+            ["application/json"] = new OpenApiMediaType
+            {
+                Example = new OpenApiObject
+                {
+                    ["mensagem"] = new OpenApiString("Request mal formada")
+                }
+            }
+        }
+    };
+
+    op.Responses["404"] = new OpenApiResponse
+    {
+        Description = "Moto não encontrada",
+        Content =
+        {
+            ["application/json"] = new OpenApiMediaType
+            {
+                Example = new OpenApiObject
+                {
+                    ["mensagem"] = new OpenApiString("Moto não encontrada")
+                }
+            }
+        }
+    };
+
+    return op;
+})
+.Produces<MotoVm>(StatusCodes.Status200OK, "application/json")
+.Produces<MessageDto>(StatusCodes.Status400BadRequest, "application/json")
+.Produces<MessageDto>(StatusCodes.Status404NotFound, "application/json");
 
 // DELETE /motos/{id}
-motorcyle.MapDelete("/{id}", async Task<Results<NoContent, NotFound, BadRequest<object>>> (
+motorcyle.MapDelete("/{id}", async Task<IResult> (
     string id, RentDbContext db, CancellationToken ct) =>
 {
-    var m = await db.Motorcycles.FindAsync(new object[] { id }, ct);
-    if (m is null) return TypedResults.NotFound();
+    if (string.IsNullOrWhiteSpace(id))
+        return Results.BadRequest(new MessageDto("Id inválido"));
 
-    if (m.HasRentals)
-        return TypedResults.BadRequest(BadRequestMsg("Cannot delete a motorcycle with existing rentals."));
+    var m = await db.Motorcycles.FindAsync(new object[] { id }, ct);
+    if (m is null)
+        return Results.BadRequest(new MessageDto("Id não encontrado"));
+
+    var hasRentals = await db.Rentals.AnyAsync(r => r.IdMotorcycle == id, ct);
+    if (hasRentals)
+        return Results.BadRequest(new MessageDto("Moto com locação ativa"));
 
     db.Motorcycles.Remove(m);
-    await db.SaveChangesAsync(ct);
-    return TypedResults.NoContent();
+
+    try
+    {
+        await db.SaveChangesAsync(ct);
+        return Results.Ok(new MessageDto("Moto removida com sucesso"));
+    }
+    catch (DbUpdateException)
+    {
+        return Results.BadRequest(new MessageDto("Dados inválidos"));
+    }
 })
 .WithSummary("Remover uma moto")
-.WithDescription("Exclui o registro de uma moto.")
-.Produces(StatusCodes.Status204NoContent)
-.Produces(StatusCodes.Status404NotFound)
-.Produces<object>(StatusCodes.Status400BadRequest);
+.WithOpenApi(op =>
+{
+    op.Responses["200"] = new OpenApiResponse
+    {
+        Description = "Moto removida com sucesso",
+        Content =
+        {
+            ["application/json"] = new OpenApiMediaType
+            {
+                Example = new OpenApiObject
+                {
+                    ["mensagem"] = new OpenApiString("Moto removida com sucesso")
+                }
+            }
+        }
+    };
+    op.Responses["400"] = new OpenApiResponse
+    {
+        Description = "Dados inválidos",
+        Content =
+        {
+            ["application/json"] = new OpenApiMediaType
+            {
+                Example = new OpenApiObject
+                {
+                    ["mensagem"] = new OpenApiString("Dados inválidos")
+                }
+            }
+        }
+    };
+
+    return op;
+})
+.Produces<MessageDto>(StatusCodes.Status200OK, "application/json")
+.Produces<MessageDto>(StatusCodes.Status400BadRequest, "application/json");
 
 
-// ===== Agrupamento "entregadores" =====
 var riders = app.MapGroup("/entregadores").WithTags("entregadores");
 
 // POST /entregadores
-riders.MapPost("", async Task<Results<Created<RiderVm>, Conflict, BadRequest<object>>> (
-     RiderCreateDto dto, RentDbContext db, CancellationToken ct) =>
+riders.MapPost("", async Task<IResult> (RiderCreateDto dto, RentDbContext db, CancellationToken ct) =>
 {
     try
     {
@@ -202,7 +385,7 @@ riders.MapPost("", async Task<Results<Created<RiderVm>, Conflict, BadRequest<obj
         db.DeliveryRiders.Add(rider);
         await db.SaveChangesAsync(ct);
 
-        return TypedResults.Created($"/entregadores/{rider.Id}",
+        return Results.Created($"/entregadores/{rider.Id}",
             new RiderVm(
                 rider.Id,
                 rider.Name,
@@ -213,17 +396,36 @@ riders.MapPost("", async Task<Results<Created<RiderVm>, Conflict, BadRequest<obj
                 rider.Cnh.CnhImageUrl
             ));
     }
-    catch (InvalidOperationException) { return TypedResults.Conflict(); }
-    catch (ArgumentException)      { return TypedResults.BadRequest(BadRequestMsg()); }
+    catch (ArgumentException)
+    {
+        return Results.BadRequest(new MessageDto("Dados inválidos"));
+    }
 })
 .WithSummary("Cadastrar entregador")
-.WithDescription("Cria um entregador (delivery rider).")
-.Produces<RiderVm>(StatusCodes.Status201Created)
-.Produces(StatusCodes.Status409Conflict)
-.Produces<object>(StatusCodes.Status400BadRequest);
+.WithOpenApi(op =>
+{
+    op.Responses.TryAdd("201", new OpenApiResponse { Description = "Entregador criado" });
+    op.Responses["400"] = new OpenApiResponse
+    {
+        Description = "Dados inválidos",
+        Content =
+        {
+            ["application/json"] = new OpenApiMediaType
+            {
+                Example = new OpenApiObject
+                {
+                    ["mensagem"] = new OpenApiString("Dados inválidos")
+                }
+            }
+        }
+    };
+    return op;
+})
+.Produces<RiderVm>(StatusCodes.Status201Created, "application/json")
+.Produces<MessageDto>(StatusCodes.Status400BadRequest, "application/json");
 
 // POST /entregadores/{id}/cnh
-riders.MapPost("/{id}/cnh", async Task<Results<NoContent, NotFound, BadRequest<object>>> (
+riders.MapPost("/{id}/cnh", async Task<IResult> (
     string id,
     CnhUploadBody body,
     IStorageService storage,
@@ -231,7 +433,7 @@ riders.MapPost("/{id}/cnh", async Task<Results<NoContent, NotFound, BadRequest<o
     CancellationToken ct) =>
 {
     if (string.IsNullOrWhiteSpace(body.imagem_cnh))
-        return TypedResults.BadRequest(BadRequestMsg("Campo 'imagem_cnh' é obrigatório."));
+        return TypedResults.BadRequest(new MessageDto("Campo 'imagem_cnh' é obrigatório."));
 
     var raw = body.imagem_cnh.Trim();
     var commaIdx = raw.IndexOf(',');
@@ -239,127 +441,301 @@ riders.MapPost("/{id}/cnh", async Task<Results<NoContent, NotFound, BadRequest<o
 
     byte[] bytes;
     try { bytes = Convert.FromBase64String(payload); }
-    catch { return TypedResults.BadRequest(BadRequestMsg("Campo 'imagem_cnh' não é um base64 válido.")); }
+    catch { return TypedResults.BadRequest(new MessageDto("Campo 'imagem_cnh' não é um base64 válido.")); }
 
     var rider = await db.DeliveryRiders.FindAsync(new object[] { id }, ct);
-    if (rider is null) return TypedResults.NotFound();
+    if (rider is null)
+        return TypedResults.NotFound(new MessageDto("Entregador não encontrado."));
 
     await using var ms = new MemoryStream(bytes);
     var fileName = $"cnh_{id}_{DateTimeOffset.UtcNow:yyyyMMddHHmmssfff}.png"; // padrão .png
     var path = await storage.SaveAsync(ms, fileName, ct);
 
     rider.UpdateCNHImage(path);
+
+    db.DeliveryRiders.Update(rider);
+
     await db.SaveChangesAsync(ct);
 
-    return TypedResults.NoContent();
+    return TypedResults.Ok(new MessageDto("Imagem da CNH atualizada com sucesso."));
 })
 .WithSummary("Enviar foto da CNH")
-.WithDescription("Recebe JSON com 'imagem_cnh' em base64 (pode ser data URL).")
-.Produces(StatusCodes.Status204NoContent)
-.Produces(StatusCodes.Status404NotFound)
-.Produces<object>(StatusCodes.Status400BadRequest);
+.WithOpenApi(op =>
+{
+    op.Responses["200"] = new OpenApiResponse
+    {
+        Description = "Upload realizado com sucesso",
+        Content =
+        {
+            ["application/json"] = new OpenApiMediaType
+            {
+                Example = new OpenApiObject { ["mensagem"] = new OpenApiString("Imagem da CNH atualizada com sucesso.") }
+            }
+        }
+    };
+
+    op.Responses["404"] = new OpenApiResponse
+    {
+        Description = "Entregador não encontrado",
+        Content =
+        {
+            ["application/json"] = new OpenApiMediaType
+            {
+                Example = new OpenApiObject { ["mensagem"] = new OpenApiString("Entregador não encontrado.") }
+            }
+        }
+    };
+
+    op.Responses["400"] = new OpenApiResponse
+    {
+        Description = "Dados inválidos",
+        Content =
+        {
+            ["application/json"] = new OpenApiMediaType
+            {
+                Example = new OpenApiObject { ["mensagem"] = new OpenApiString("Campo 'imagem_cnh' é obrigatório.") }
+            }
+        }
+    };
+
+    return op;
+})
+.Produces<MessageDto>(StatusCodes.Status200OK, "application/json")
+.Produces<MessageDto>(StatusCodes.Status404NotFound, "application/json")
+.Produces<MessageDto>(StatusCodes.Status400BadRequest, "application/json");
+
 
 var rentals = app.MapGroup("/locação").WithTags("locação");
 
 // POST /locacao
-rentals.MapPost("", async Task<Results<Created<RentalCreateDto>, BadRequest<object>, Conflict>> (
+rentals.MapPost("", async Task<IResult> (
     RentalCreateDto dto, RentDbContext db, CancellationToken ct) =>
 {
     var rider = await db.DeliveryRiders.FindAsync(new object[] { dto.riderId }, ct);
     if (rider is null)
-        return TypedResults.BadRequest(BadRequestMsg("Entregador inexistente."));
+        return TypedResults.BadRequest(new MessageDto("Entregador inexistente."));
 
     var moto = await db.Motorcycles.FindAsync(new object[] { dto.motorcycleId }, ct);
     if (moto is null)
-        return TypedResults.BadRequest(BadRequestMsg("Moto inexistente."));
+        return TypedResults.BadRequest(new MessageDto("Moto inexistente."));
 
     try
     {
         var plan = ParsePlan(dto.plan);
 
         var rental = Rental.Create(
-            riderId:         dto.riderId,
-            motorcycleId:    dto.motorcycleId,
-            startDate:       dto.startDate,
-            endDate:         dto.endDate,
+            riderId: dto.riderId,
+            motorcycleId: dto.motorcycleId,
+            startDate: dto.startDate,
+            endDate: dto.endDate,
             expectedEndDate: dto.expectedEndDate,
-            plan:            plan
+            plan: plan
         );
 
         db.Rentals.Add(rental);
         await db.SaveChangesAsync(ct);
 
         var vm = new RentalCreateDto(
-            riderId:         rental.IdDeliveryRider,
-            motorcycleId:    rental.IdMotorcycle,
-            startDate:       rental.StartDate,
-            endDate:         rental.EndDate,
+            riderId: rental.IdDeliveryRider,
+            motorcycleId: rental.IdMotorcycle,
+            startDate: rental.StartDate,
+            endDate: rental.EndDate,
             expectedEndDate: rental.ExpectedEndDate,
-            plan:            (int)rental.Plan
+            plan: (int)rental.Plan
         );
 
         return TypedResults.Created($"/locacao/{rental.Id}", vm);
     }
-    catch (InvalidOperationException) { return TypedResults.Conflict(); }
-    catch (ArgumentException ex)      { return TypedResults.BadRequest(BadRequestMsg(ex.Message)); }
+    catch (ArgumentException)
+    {
+        return Results.BadRequest(new MessageDto("Dados inválidos"));
+    }
 })
 .WithSummary("Alugar uma moto")
-.WithDescription("Cria uma locação para um entregador.")
-.Produces<RentalCreateDto>(StatusCodes.Status201Created)
-.Produces(StatusCodes.Status409Conflict)
-.Produces<object>(StatusCodes.Status400BadRequest);
+.WithOpenApi(op =>
+{
+    op.Responses.TryAdd("201", new OpenApiResponse { Description = "Moto cadastrada" });
+    op.Responses["400"] = new OpenApiResponse
+    {
+        Description = "Dados inválidos",
+        Content =
+        {
+            ["application/json"] = new OpenApiMediaType
+            {
+                Example = new OpenApiObject
+                {
+                    ["mensagem"] = new OpenApiString("Dados inválidos")
+                }
+            }
+        }
+    };
+    return op;
+})
+.Produces<RiderVm>(StatusCodes.Status201Created, "application/json")
+.Produces<MessageDto>(StatusCodes.Status400BadRequest, "application/json");
 
 
 // GET /locacao/{id}
-rentals.MapGet("/{id:int}", async (int id, RentDbContext db, CancellationToken ct) =>
+rentals.MapGet("/{id}", async (string identifier, RentDbContext db, CancellationToken ct) =>
 {
-    var r = await db.Rentals.FindAsync(new object[] { id }, ct);
-    if (r is null) return Results.NotFound();
+    if (string.IsNullOrWhiteSpace(identifier))
+        return Results.BadRequest(new MessageDto("Parâmetro 'Id' é obrigatório."));
+
+    int idValue;
+    if (identifier.StartsWith("locacao", StringComparison.OrdinalIgnoreCase))
+    {
+        var numericPart = identifier["locacao".Length..].Trim();
+        if (!int.TryParse(numericPart, out idValue))
+            return Results.BadRequest(new MessageDto("Identifier inválido. Use 'locacao{Id}', por exemplo: 'locacao1'."));
+    }
+    else
+    {
+        if (!int.TryParse(identifier, out idValue))
+            return Results.BadRequest(new MessageDto("Identifier inválido. Use 'locacao{Id}', por exemplo: 'locacao1'."));
+    }
+
+    var r = await db.Rentals.FindAsync(new object[] { idValue }, ct);
+    if (r is null)
+        return Results.NotFound(new MessageDto("Locação não encontrada"));
 
     var vm = new RentalVm(
-        identifier:       r.Identifier,
-        dailyPrice:       r.DailyPrice,
-        riderId:          r.IdDeliveryRider,
-        motorcycleId:     r.IdMotorcycle,
-        startDate:        r.StartDate,
-        termDate:         r.ExpectedEndDate,
-        expectedEndDate:  r.ExpectedEndDate,
-        returnDate:       r.ReturnDate
+        identifier: r.Identifier,
+        dailyPrice: r.DailyPrice,
+        riderId: r.IdDeliveryRider,
+        motorcycleId: r.IdMotorcycle,
+        startDate: r.StartDate,
+        termDate: r.ExpectedEndDate,
+        expectedEndDate: r.ExpectedEndDate,
+        returnDate: r.ReturnDate
     );
 
     return Results.Ok(vm);
 })
 .WithSummary("Consultar locação por id")
-.WithDescription("Retorna os dados de uma locação específica.")
-.Produces<RentalVm>(StatusCodes.Status200OK)
-.Produces(StatusCodes.Status404NotFound);
+.WithOpenApi(op =>
+{
+    op.Responses["200"] = new OpenApiResponse
+    {
+        Description = "Detalhes da locação",
+        Content =
+        {
+            ["application/json"] = new OpenApiMediaType
+            {
+                Example = new OpenApiObject
+                {
+                    ["identificador"]      = new OpenApiString("locacao1"),
+                    ["valor_diaria"]      = new OpenApiDouble(10),
+                    ["entregador_id"]         = new OpenApiString("entregador123"),
+                    ["moto_id"]    = new OpenApiString("moto123"),
+                    ["data_inicio"]       = new OpenApiString("2024-01-01T00:00:00Z"),
+                    ["data_termino"]        = new OpenApiString("2024-01-07T23:59:59Z"),
+                    ["data_previsao_termino"] = new OpenApiString("2024-01-07T23:59:59Z"),
+                    ["data_devolucao"]      = new OpenApiString("2024-01-07T18:00:00Z")
+                }
+            }
+        }
+    };
+
+    op.Responses["404"] = new OpenApiResponse { Description = "Dados não encontrados" };
+
+    op.Responses["400"] = new OpenApiResponse
+    {
+        Description = "Dados inválidos",
+        Content =
+        {
+            ["application/json"] = new OpenApiMediaType
+            {
+                Example = new OpenApiObject
+                {
+                    ["mensagem"] = new OpenApiString("Id inválido. Use 'locacao{Id}', por exemplo: 'locacao1'.")
+                }
+            }
+        }
+    };
+
+    return op;
+})
+.Produces<RentalVm>(StatusCodes.Status200OK, "application/json")
+.Produces<MessageDto>(StatusCodes.Status404NotFound, "application/json")
+.Produces<MessageDto>(StatusCodes.Status400BadRequest, "application/json");
+
 
 // PUT /locacao/{id}/devolucao
-rentals.MapPut("/{id:int}/devolucao", async Task<Results<Ok<PreviewVm>, NotFound, BadRequest<object>>> (
-    int id, ReturnDto dto, RentDbContext db, CancellationToken ct) =>
+rentals.MapPut("/{id}/devolucao", async Task<IResult> (
+    string identifier,
+    ReturnDto dto,
+    RentDbContext db,
+    CancellationToken ct) =>
 {
-    var r = await db.Rentals.FindAsync(new object[] { id }, ct);
-    if (r is null) return TypedResults.NotFound();
+    if (string.IsNullOrWhiteSpace(identifier))
+        return Results.BadRequest(new MessageDto("Parâmetro 'identifier' é obrigatório."));
+
+    int idValue;
+    if (identifier.StartsWith("locacao", StringComparison.OrdinalIgnoreCase))
+    {
+        var numericPart = identifier["locacao".Length..].Trim();
+        if (!int.TryParse(numericPart, out idValue))
+            return Results.BadRequest(new MessageDto("Error de identificacao"));
+    }
+    else
+    {
+        if (!int.TryParse(identifier, out idValue))
+            return Results.BadRequest(new MessageDto("Error de parse"));
+    }
+
+    var r = await db.Rentals.FindAsync(new object[] { idValue }, ct);
+    if (r is null)
+        return Results.NotFound(new MessageDto("Locação não encontrada"));
 
     try
     {
         var pb = r.CalculatePreview(dto.returnDate);
-        return TypedResults.Ok(new PreviewVm(
-            pb.UsedDays, pb.UnusedDays, pb.ExtraDays,
-            pb.DailyPrice, pb.BaseValue, pb.Penalty, pb.Extras, pb.Total
+        return Results.Ok(new PreviewVm(
+            pb.UsedDays,
+            pb.UnusedDays,
+            pb.ExtraDays,
+            pb.DailyPrice,
+            pb.BaseValue,
+            pb.Penalty,
+            pb.Extras,
+            pb.Total
         ));
     }
-    catch (ArgumentException ex) { return TypedResults.BadRequest(BadRequestMsg(ex.Message)); }
+    catch (ArgumentException ex)
+    {
+        return Results.BadRequest(new MessageDto(ex.Message));
+    }
 })
 .WithSummary("Informar data de devolução e calcular valor")
-.WithDescription("Calcula o preview do valor total da locação ao informar a data de devolução.")
-.Produces<PreviewVm>(StatusCodes.Status200OK)
-.Produces(StatusCodes.Status404NotFound)
-.Produces<object>(StatusCodes.Status400BadRequest);
+.WithOpenApi(op =>
+{
+    op.Responses["200"] = new OpenApiResponse
+    {
+        Description = "Data de devolução informada com sucesso"
+    };
+
+
+    op.Responses["400"] = new OpenApiResponse
+    {
+        Description = "Dados inválidos",
+        Content =
+        {
+            ["application/json"] = new OpenApiMediaType
+            {
+                Example = new OpenApiObject
+                {
+                    ["mensagem"] = new OpenApiString("Dados inválidos")
+                }
+            }
+        }
+    };
+
+    return op;
+})
+.Produces<PreviewVm>(StatusCodes.Status200OK, "application/json")
+.Produces<MessageDto>(StatusCodes.Status400BadRequest, "application/json");
 
 app.Run();
-
-static object BadRequestMsg(string msg = "Dados inválidos") => new { message = msg };
 
 static CNHType ParseCnhType(string s)
 {
@@ -375,12 +751,12 @@ static CNHType ParseCnhType(string s)
 
 static RentalPlan ParsePlan(int n) => n switch
 {
-    7  => RentalPlan.Days7,
+    7 => RentalPlan.Days7,
     15 => RentalPlan.Days15,
     30 => RentalPlan.Days30,
     45 => RentalPlan.Days45,
     50 => RentalPlan.Days50,
-    _  => throw new ArgumentException("Invalid plan")
+    _ => throw new ArgumentException("Invalid plan")
 };
 
 static string NormalizeCnpj(string cnpj) => new string((cnpj ?? "").Where(char.IsDigit).ToArray());


### PR DESCRIPTION
## Description
This PR introduces a response format across API endpoints by using a new `MessageDto` record for both success and error messages.  
It replaces ad-hoc `BadRequest` helpers and ensuring clearer and more predictable responses for clients.  

## Changes Included
- Replaced ad-hoc BadRequest helpers and anonymous objects with a new sealed record `MessageDto
- Updated POST, PUT, and GET endpoints to return consistent responses.
- Changed 204 NoContent responses to 200 OK with a MessageDto body for better client feedback.
- Improved Swagger/OpenAPI documentation to include structured examples of error/success messages.
- Ensured all validation and error cases return MessageDto for consistency across the API.
